### PR TITLE
Fix some build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
+add_compile_options(-Wno-incompatible-pointer-types)
 
 #set this to true to ship the game!
 #! ! ! ! ! ! !

--- a/src/gameLayer/gameLayer.cpp
+++ b/src/gameLayer/gameLayer.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 #include <enemy.h>
 #include <cstdio>
+#include <ctime>
 #include <glui/glui.h>
 #include <raudio.h>
 


### PR DESCRIPTION
When I tried to build this project on my Linux system, I've got two different types of errors:
1- Incompatible pointer types errors:
```console
/home/mrunix/game-in-cpp-full-course/thirdparty/raudio/src/raudio.c:1998:114: error: passing argument 5 of ‘drflac_open_memory_and_read_pcm_frames_s16’ from incompatible pointer type [-Wincompatible-pointer-types]
 1998 |     wave.data = drflac_open_memory_and_read_pcm_frames_s16(fileData, fileSize, &wave.channels, &wave.sampleRate, &totalSampleCount);
      |                                                                                                                  ^~~~~~~~~~~~~~~~~
      |                                                                                                                  |
      |                                                                                                                  long long unsigned int *
In file included from /home/mrunix/game-in-cpp-full-course/thirdparty/raudio/src/raudio.c:244:
/home/mrunix/game-in-cpp-full-course/thirdparty/raudio/include/external/dr_flac.h:8457:158: note: expected ‘drflac_uint64 *’ {aka ‘long unsigned int *’} but argument is of type ‘long long unsigned int *’
 8457 | drflac_int16* drflac_open_memory_and_read_pcm_frames_s16(const void* data, size_t dataSize, unsigned int* channels, unsigned int* sampleRate, drflac_uint64* totalPCMFrameCount)
      |                                                                                                                                               ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
/home/mrunix/game-in-cpp-full-course/thirdparty/raudio/src/raudio.c: In function ‘LoadMP3’:
/home/mrunix/game-in-cpp-full-course/thirdparty/raudio/src/raudio.c:2029:77: error: passing argument 4 of ‘drmp3_open_memory_and_read_f32’ from incompatible pointer type [-Wincompatible-pointer-types]
 2029 |     wave.data = drmp3_open_memory_and_read_f32(fileData, fileSize, &config, &totalFrameCount);
      |                                                                             ^~~~~~~~~~~~~~~~
      |                                                                             |
      |                                                                             long long unsigned int *
```
2- std::time not found
```console
/home/mrunix/game-in-cpp-full-course/src/gameLayer/gameLayer.cpp:74:25: error: ‘time’ is not a member of ‘std’; did you mean ‘tie’?
   74 |         std::srand(std::time(0));
      |                         ^~~~
      |                         tie
```
This PR fixes both of these errors